### PR TITLE
Logout URL

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -38,10 +38,11 @@ final class SettingsForm extends ConfigFormBase {
     ];
 
     $form['logout_url'] = [
-      '#type' => 'textfield',
+      '#type' => 'url',
       '#title' => $this->t('Logout URL'),
       '#default_value' => $this->config('bfi_mini_orange.settings')->get('logout_url'),
       '#description' => $this->t('URL to logout from the IdP.'),
+      '#required' => TRUE,
       '#attributes' => [
         'placeholder' => $this->t('E.g. https://login.microsoftonline.com/[tenant_id]/oauth2/logout'),
       ],


### PR DESCRIPTION
Convert textfield to url field for the IdP logout URL in the settings form and make it a required field.